### PR TITLE
Let it run under WSL

### DIFF
--- a/quant_infer.py
+++ b/quant_infer.py
@@ -1,29 +1,34 @@
 import hiq, time
 from hiq.memory import total_gpu_memory_mb, get_memory_mb
+import platform
 
 
 def main():
+
+    try:
+        wsl = 'microsoft' in platform.uname()[2].lower()
+    except:
+        wsl = False
+
     driver = hiq.HiQLatency(
         hiq_table_or_path=[
-          ["llama.llama_infer", "", "run", "run_quant"],
-          ["llama.llama_infer", "LLaMATokenizer", "from_pretrained", "from_pretrained"],
-          ["llama.hf", "LLaMATokenizer", "encode", "encode"],
-          ["llama.llama_infer", "", "load_quant", "load_quant"],
-          ["llama.hf.modeling_llama","LLaMAForCausalLM","generate","generate"]
+            ["llama.llama_infer", "", "run", "run_quant"],
+            ["llama.llama_infer", "LLaMATokenizer", "from_pretrained", "from_pretrained"],
+            ["llama.hf", "LLaMATokenizer", "encode", "encode"],
+            ["llama.llama_infer", "", "load_quant", "load_quant"],
+            ["llama.hf.modeling_llama", "LLaMAForCausalLM", "generate", "generate"]
         ],
-        metric_funcs=[time.time, total_gpu_memory_mb, get_memory_mb],
+        metric_funcs=[time.time, get_memory_mb] + ([total_gpu_memory_mb] if not wsl else []),  # WSL does not contain nvidia-smi
         # extra_metrics={hiq.ExtraMetrics.ARGS},
     )
 
     args = hiq.mod("llama.llama_infer").get_args()
     hiq.mod("llama.llama_infer").run(args)
-    print("*" * 30, "GPU/CPU/Latency Profiling", "*" * 30)
+    print("*" * 30, ("GPU/" if not wsl else "") + "CPU/Latency Profiling", "*" * 30)
+    if wsl:
+        print('(WSL does not contain nvidia-smi, GPU profiling is disabled)')
     driver.show()
 
 
 if __name__ == "__main__":
     main()
-
-
-
-


### PR DESCRIPTION
WSL does not contain `nvidia-smi` which the `hiq` rely on to profile the GPU usage and results with an error:
```
Traceback (most recent call last):
  File "quant_infer.py", line 31, in <module>
    main()
  File "quant_infer.py", line 25, in main
    hiq.mod("llama.llama_infer").run(args)
  File "/usr/local/lib/python3.8/dist-packages/hiq/base.py", line 365, in __x
    s.pre_processing(f_name, args, kwargs)
  File "/usr/local/lib/python3.8/dist-packages/hiq/utils.py", line 493, in __y
    r = f(s, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/hiq/base.py", line 292, in pre_processing
    tmp.start(f_name, func(), extra=an_extra)
  File "/usr/local/lib/python3.8/dist-packages/hiq/memory.py", line 74, in total_gpu_memory_mb_nvidia_smi
    output = execute_cmd(cmd, verbose=False)
  File "/usr/local/lib/python3.8/dist-packages/hiq/utils.py", line 116, in execute_cmd
    result = subprocess.run(
  File "/usr/lib/python3.8/subprocess.py", line 493, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'nvidia-smi'
```

This additional code checks if the subsystem is WSL and disables GPU profiling.