### PR TITLE
add a shebang to all shell files

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the GNU General Public License version 3.
 

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # UPDATE from Shawn (Mar 5 @ 2:43 AM)
 
 echo "❤️ Resume download is supported. You can ctrl-c and rerun the program to resume the downloading"

--- a/llama/download_community_stop.sh
+++ b/llama/download_community_stop.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 ps aux | grep 'wget --continue --progress=bar:force https://agi.gpt4.org/llama/LLaMA/' | grep -v grep | awk '{print $2}' | xargs kill
 ps aux | grep '.*llama/download_community.sh' | grep -v grep | awk '{print $2}' | xargs kill


### PR DESCRIPTION
on macs, /bin/bash is an old version but many users have installed newer versions via homebrew. In this case, env bash will return the proper bash, which is needed to run the shell scripts as they depend on bash 4+ while mac ships an ancient bash version.

Idea from @anentropic, see https://github.com/juncongmoo/pyllama/issues/47#issuecomment-1499265114