### PR TITLE
rewrite download_community.sh

### DIFF
--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -9,7 +9,7 @@ RED=$(tput setaf 1)
 CLEAR=$(tput sgr0)
 
 function usage {
-    cat <<"EOF"
+    cat <<EOF
 Usage: download_community [-vh] [<models>] [<output_directory>]
 
 Download the given llama <models> to <output_directory>. By default, will download 

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -107,7 +107,7 @@ while true; do
 done
 
 # MODELS_TO_DOWNLOAD is a comma-separated list of models the user wants to
-# download, which defaults to all models. Split it into an array calld MODELS
+# download, which defaults to all models. Split it into an array called MODELS
 MODELS_TO_DOWNLOAD=${1:-$ALL_MODELS}
 IFS="," read -r -a MODELS <<< "$MODELS_TO_DOWNLOAD"
 

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 PRESIGNED_URL="https://agi.gpt4.org/llama/LLaMA"
 ALL_MODELS=7B,13B,30B,65B
 
-YELLOW=$(tput setaf 1)
-RED=$(tput setaf 3)
+YELLOW=$(tput setaf 3)
+RED=$(tput setaf 1)
 CLEAR=$(tput sgr0)
 
 function usage {
@@ -35,7 +35,7 @@ EOF
 
 # print its argument in red and quit 
 function die {
-    printf "%s%s%s\n", "$RED", "$1", "$CLEAR"
+    printf "%s%s%s\n" "$RED", "$1", "$CLEAR"
     exit 1
 }
 
@@ -113,7 +113,7 @@ echo "❤️  Resume download is supported. You can ctrl-c and rerun the program
 # ensure the targeted directory exists
 mkdir -p "$TARGET_FOLDER"
 
-printf "%sDownloading tokenizer...%s\n" "$YELLOW" "$CLEAR"
+printf "\n%sDownloading tokenizer...%s\n" "$YELLOW" "$CLEAR"
 download "$PRESIGNED_URL/tokenizer.model" "$TARGET_FOLDER/tokenizer.model"
 download "$PRESIGNED_URL/tokenizer_checklist.chk" "$TARGET_FOLDER/tokenizer_checklist.chk"
 verify "$TARGET_FOLDER" tokenizer_checklist.chk
@@ -131,9 +131,11 @@ do
         echo "downloading file to $fout ...please wait for a few minutes ..."
         download "$PRESIGNED_URL/$model/consolidated.$s.pth" "$fout"
     done
-    download "$PRESIGNED_URL/params.json" "$TARGET_FOLDER/$model/params.json"
-    download "$PRESIGNED_URL/checklist.chk" "$TARGET_FOLDER/$model/checklist.chk"
 
-    printf "%sChecking checksums%s" "$YELLOW" "$CLEAR"
+    # download the params and checksums
+    download "$PRESIGNED_URL/$model/params.json" "$TARGET_FOLDER/$model/params.json"
+    download "$PRESIGNED_URL/$model/checklist.chk" "$TARGET_FOLDER/$model/checklist.chk"
+
+    printf "\n%sChecking checksums%s\n" "$YELLOW" "$CLEAR"
     verify "$TARGET_FOLDER/$model" checklist.chk
 done

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -35,13 +35,13 @@ EOF
 
 # print its argument in red and quit 
 function die {
-    printf "%s%s%s\n" "$RED", "$1", "$CLEAR"
+    printf "%s%s%s\n" "$RED" "$1" "$CLEAR"
     exit 1
 }
 
 # print its argument in yellow
 function log {
-    printf "\n%s$1%s\n" "$YELLOW" "$CLEAR"
+    printf "\n%s%s%s\n" "$YELLOW" "$1" "$CLEAR"
 }
 
 # download a file with a progress bar, then display a success message. Takes

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -12,7 +12,8 @@ function usage {
     cat <<EOF
 Usage: download_community [-vh] [<models>] [<output_directory>]
 
-Download the given llama <models> to <output_directory>. By default, will download 
+Download the given llama <models> to <output_directory>. By default, will
+download all available models into the current directory
 
 OPTIONS
 

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -127,15 +127,15 @@ do
     # download each shard in the model
     for s in $(seq -f "0%g" 0 "$(nshards "$model")")
     do
-        fout="$TARGET_FOLDER/$model/consolidated.$s.pth"
-        echo "downloading file to $fout ...please wait for a few minutes ..."
-        download "$PRESIGNED_URL/$model/consolidated.$s.pth" "$fout"
+       fout="$TARGET_FOLDER/$model/consolidated.$s.pth"
+       echo "downloading file to $fout ...please wait for a few minutes ..."
+       download "$PRESIGNED_URL/$model/consolidated.$s.pth" "$fout"
     done
 
     # download the params and checksums
     download "$PRESIGNED_URL/$model/params.json" "$TARGET_FOLDER/$model/params.json"
     download "$PRESIGNED_URL/$model/checklist.chk" "$TARGET_FOLDER/$model/checklist.chk"
 
-    printf "\n%sChecking checksums%s\n" "$YELLOW" "$CLEAR"
+    printf "\n%sChecking checksums for the $model model%s\n" "$YELLOW" "$CLEAR"
     verify "$TARGET_FOLDER/$model" checklist.chk
 done

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -42,7 +42,7 @@ function die {
 # download a file with a progress bar, then display a success message. Takes
 # two arguments: the URL and the output file name
 function download {
-    if ! wget --progress=bar:force "$1" -O "$2"; then
+    if ! wget --continue --progress=bar:force "$1" -O "$2"; then
         die "failed to download $1 -> $2"
     fi
     echo ✅ "$2"

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -39,6 +39,11 @@ function die {
     exit 1
 }
 
+# print its argument in yellow
+function log {
+    printf "\n%s$1%s\n" "$YELLOW" "$CLEAR"
+}
+
 # download a file with a progress bar, then display a success message. Takes
 # two arguments: the URL and the output file name
 function download {
@@ -108,12 +113,12 @@ IFS="," read -r -a MODELS <<< "$MODELS_TO_DOWNLOAD"
 # TARGET_FOLDER is the root directory to download the models to
 TARGET_FOLDER=${2:-.}
 
-echo "❤️  Resume download is supported. You can ctrl-c and rerun the program to resume the downloading"
+log "❤️  Resume download is supported. You can ctrl-c and rerun the program to resume the downloading"
 
 # ensure the targeted directory exists
 mkdir -p "$TARGET_FOLDER"
 
-printf "\n%sDownloading tokenizer...%s\n" "$YELLOW" "$CLEAR"
+log "Downloading tokenizer..."
 download "$PRESIGNED_URL/tokenizer.model" "$TARGET_FOLDER/tokenizer.model"
 download "$PRESIGNED_URL/tokenizer_checklist.chk" "$TARGET_FOLDER/tokenizer_checklist.chk"
 verify "$TARGET_FOLDER" tokenizer_checklist.chk
@@ -121,14 +126,14 @@ verify "$TARGET_FOLDER" tokenizer_checklist.chk
 # for each model, download each of its shards and then verify the checksums
 for model in "${MODELS[@]}"
 do
-    echo "Downloading $model"
+    log "Downloading $model"
     mkdir -p "$TARGET_FOLDER/$model"
 
     # download each shard in the model
     for s in $(seq -f "0%g" 0 "$(nshards "$model")")
     do
        fout="$TARGET_FOLDER/$model/consolidated.$s.pth"
-       echo "downloading file to $fout ...please wait for a few minutes ..."
+       log "downloading file to $fout ...please wait for a few minutes ..."
        download "$PRESIGNED_URL/$model/consolidated.$s.pth" "$fout"
     done
 
@@ -136,6 +141,6 @@ do
     download "$PRESIGNED_URL/$model/params.json" "$TARGET_FOLDER/$model/params.json"
     download "$PRESIGNED_URL/$model/checklist.chk" "$TARGET_FOLDER/$model/checklist.chk"
 
-    printf "\n%sChecking checksums for the $model model%s\n" "$YELLOW" "$CLEAR"
+    log "Checking checksums for the $model model"
     verify "$TARGET_FOLDER/$model" checklist.chk
 done

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -78,6 +78,12 @@ function nshards {
 
 }
 
+# check for wget - if it's not present print an error
+if ! command -v wget &> /dev/null
+then
+    die "wget not found. You must have wget installed and on your path to run this script"
+fi
+
 # parse the optional flags and discard them
 while true; do
     case $1 in
@@ -102,7 +108,7 @@ IFS="," read -r -a MODELS <<< "$MODELS_TO_DOWNLOAD"
 # TARGET_FOLDER is the root directory to download the models to
 TARGET_FOLDER=${2:-.}
 
-echo "❤️ Resume download is supported. You can ctrl-c and rerun the program to resume the downloading"
+echo "❤️  Resume download is supported. You can ctrl-c and rerun the program to resume the downloading"
 
 # ensure the targeted directory exists
 mkdir -p "$TARGET_FOLDER"

--- a/llama/download_community.sh
+++ b/llama/download_community.sh
@@ -1,50 +1,133 @@
-#!/bin/bash
-# UPDATE from Shawn (Mar 5 @ 2:43 AM)
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRESIGNED_URL="https://agi.gpt4.org/llama/LLaMA"
+ALL_MODELS=7B,13B,30B,65B
+
+YELLOW=$(tput setaf 1)
+RED=$(tput setaf 3)
+CLEAR=$(tput sgr0)
+
+function usage {
+    cat <<"EOF"
+Usage: download_community [-vh] [<models>] [<output_directory>]
+
+Download the given llama <models> to <output_directory>. By default, will download 
+
+OPTIONS
+
+  -v, --verbose: enable verbose mode
+  -h, --help:    print this help and exit
+
+EXAMPLES
+
+Download all models ($ALL_MODELS) into the current directory
+
+  ./download_community.sh
+
+Download the 7B and 13B parameter models to /usr/share/llama
+    
+  ./download_community.sh 7B,13B /usr/share/llama
+
+EOF
+    exit 1
+}
+
+# print its argument in red and quit 
+function die {
+    printf "%s%s%s\n", "$RED", "$1", "$CLEAR"
+    exit 1
+}
+
+# download a file with a progress bar, then display a success message. Takes
+# two arguments: the URL and the output file name
+function download {
+    if ! wget --progress=bar:force "$1" -O "$2"; then
+        die "failed to download $1 -> $2"
+    fi
+    echo ✅ "$2"
+}
+
+# change into the model directory and use md5sum -c to verify the checksums of
+# the model files within. Uses a subshell to avoid changing the script's
+# direcotry
+function verify {
+    (cd "$1" && md5sum -c "$2")
+}
+
+# return the number of shards for a given model. Bash 3 doesn't support
+# associative arrays, so use a case statement instead.
+function nshards {
+    case $1 in
+        7B)
+            echo 0
+            ;;
+        13B)
+            echo 1
+            ;;
+        30B)
+            echo 3
+            ;;
+        65B)
+            echo 7
+            ;;
+        *)
+            die "invalid argument to nshards: $1"
+            ;;
+    esac
+
+}
+
+# parse the optional flags and discard them
+while true; do
+    case $1 in
+        -v|--verbose)
+            set -x
+            shift
+            ;;
+        -h|--help|help)
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# MODELS_TO_DOWNLOAD is a comma-separated list of models the user wants to
+# download, which defaults to all models. Split it into an array calld MODELS
+MODELS_TO_DOWNLOAD=${1:-$ALL_MODELS}
+IFS="," read -r -a MODELS <<< "$MODELS_TO_DOWNLOAD"
+
+# TARGET_FOLDER is the root directory to download the models to
+TARGET_FOLDER=${2:-.}
 
 echo "❤️ Resume download is supported. You can ctrl-c and rerun the program to resume the downloading"
 
-PRESIGNED_URL="https://agi.gpt4.org/llama/LLaMA/*"
+# ensure the targeted directory exists
+mkdir -p "$TARGET_FOLDER"
 
-MODEL_SIZE=${1:-7B,13B,30B,65B}  # edit this list with the model sizes you wish to download
-TARGET_FOLDER=${2:-./}           # where all files should end up
+printf "%sDownloading tokenizer...%s\n" "$YELLOW" "$CLEAR"
+download "$PRESIGNED_URL/tokenizer.model" "$TARGET_FOLDER/tokenizer.model"
+download "$PRESIGNED_URL/tokenizer_checklist.chk" "$TARGET_FOLDER/tokenizer_checklist.chk"
+verify "$TARGET_FOLDER" tokenizer_checklist.chk
 
-if [ $TARGET_FOLDER != "./" ]; then
-    mkdir -p $TARGET_FOLDER
-fi
-
-declare -A N_SHARD_DICT
-
-N_SHARD_DICT["7B"]="0"
-N_SHARD_DICT["13B"]="1"
-N_SHARD_DICT["30B"]="3"
-N_SHARD_DICT["65B"]="7"
-
-set -x
-echo "Downloading tokenizer..."
-wget --progress=bar:force ${PRESIGNED_URL/'*'/"tokenizer.model"} -O ${TARGET_FOLDER}"/tokenizer.model"
-echo ✅ ${TARGET_FOLDER}"/tokenizer.model"
-wget --progress=bar:force ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -O ${TARGET_FOLDER}"/tokenizer_checklist.chk"
-echo ✅ ${TARGET_FOLDER}"/tokenizer_checklist.chk"
-
-(cd ${TARGET_FOLDER} && md5sum -c tokenizer_checklist.chk)
-
-for i in ${MODEL_SIZE//,/ }
+# for each model, download each of its shards and then verify the checksums
+for model in "${MODELS[@]}"
 do
-    echo "Downloading ${i}"
-    mkdir -p ${TARGET_FOLDER}"/${i}"
-    for s in $(seq -f "0%g" 0 ${N_SHARD_DICT[$i]})
+    echo "Downloading $model"
+    mkdir -p "$TARGET_FOLDER/$model"
+
+    # download each shard in the model
+    for s in $(seq -f "0%g" 0 "$(nshards "$model")")
     do
-        #echo running: wget --continue --progress=bar:force ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
-        echo "downloading file to" ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth" ...please wait for a few minutes ...
-        wget --continue --progress=bar:force ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
-        echo ✅ ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
+        fout="$TARGET_FOLDER/$model/consolidated.$s.pth"
+        echo "downloading file to $fout ...please wait for a few minutes ..."
+        download "$PRESIGNED_URL/$model/consolidated.$s.pth" "$fout"
     done
-    wget --progress=bar:force ${PRESIGNED_URL/'*'/"${i}/params.json"} -O ${TARGET_FOLDER}"/${i}/params.json"
-    echo ✅ ${TARGET_FOLDER}"/${i}/params.json"
-    wget --progress=bar:force ${PRESIGNED_URL/'*'/"${i}/checklist.chk"} -O ${TARGET_FOLDER}"/${i}/checklist.chk"
-    echo ✅ ${TARGET_FOLDER}"/${i}/checklist.chk"
-    echo "Checking checksums"
-    (cd ${TARGET_FOLDER}"/${i}" && md5sum -c checklist.chk)
+    download "$PRESIGNED_URL/params.json" "$TARGET_FOLDER/$model/params.json"
+    download "$PRESIGNED_URL/checklist.chk" "$TARGET_FOLDER/$model/checklist.chk"
+
+    printf "%sChecking checksums%s" "$YELLOW" "$CLEAR"
+    verify "$TARGET_FOLDER/$model" checklist.chk
 done
-
-


### PR DESCRIPTION
This PR is a rewrite of download_commity.sh. Its primary focus is readability and compatibility with older bash versions. (see https://github.com/juncongmoo/pyllama/issues/47#issuecomment-1499265114 for why it doesn't work with bash 3, which (unfortunately) is mac's default bash version).

- remove use of associative arrays for compatibility with bash 3
- move repetitive tasks into functions and add comments
- use a simpler method to join URL paths
- add usage information, as well as the `-h` and `-v` arguments for "help" and "verbose respectively
- use color to better show the user what the script is up to
- check for `wget` and give the user an error if they don't have wget installed

I tested it by doing `/bin/bash download_community.sh 7B,13B /tmp/llama-models` on an m1 mac, which runs the script with bash 3.2.57.

Shellcheck reports no warnings:

```
$ shellcheck download_community.sh
```

on the version of the script in main, it shows many warnings.